### PR TITLE
Delete Remote Zoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Many sites aggregate job listing from a variety of sources, it can 'sometimes' b
 | ❇️ | [Remotely Awesome Jobs](https://www.remotelyawesomejobs.com/) | Jobs board aggregator. |🌟|
 | ❇️ | [Who Is Hiring](https://whoishiring.io) | Jobs board aggregator. |🌟|
 | ❇️ | [Go Remote Jobs](https://goremotejobs.com/) | Jobs board aggregator. |🌟|
-| ❇️ | [Remote Zoo](https://www.remotezoo.com/) | Jobs board aggregator. |🌟|
 
 ### 📌 Job boards
 


### PR DESCRIPTION
Empty listings and expired SSL certificate for 250 days now.