### PR TITLE
Add Ruby On Remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Many sites aggregate job listing from a variety of sources, it can 'sometimes' b
 | ❇️ | [Who Is Hiring](https://whoishiring.io) | Jobs board aggregator. |🌟|
 | ❇️ | [Go Remote Jobs](https://goremotejobs.com/) | Jobs board aggregator. |🌟|
 | ❇️ | [Remote Zoo](https://www.remotezoo.com/) | Jobs board aggregator. |🌟|
+| ❇️ | [Ruby On Remote](https://rubyonremote.com/) | Jobs board aggregator. |🌟|
 
 ### 📌 Job boards
 


### PR DESCRIPTION
Ruby On Remote (https://rubyonremote.com/) aggregates Remote jobs for Ruby developers