### PR TITLE
Added Career Vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Many sites aggregate job listing from a variety of sources, it can 'sometimes' b
 | ❇️ | [Who Is Hiring](https://whoishiring.io) | Jobs board aggregator. |🌟|
 | ❇️ | [Go Remote Jobs](https://goremotejobs.com/) | Jobs board aggregator. |🌟|
 | ❇️ | [Remote Zoo](https://www.remotezoo.com/) | Jobs board aggregator. |🌟|
+| ❇️ | [Career Vault](https://www.careervault.io/) | Jobs board aggregator. |🌟|
 
 ### 📌 Job boards
 


### PR DESCRIPTION
Career Vault scrapes jobs from 2500+ company career pages every few hours and links applicants directly to the original job postings. It's free for job seekers and companies, doesn't require signing up, and doesn't have any obsolete postings (those are automatically deleted). It's focused on remote jobs but also includes a large section with on-site positions.